### PR TITLE
Fixes optional and required parameters from scripted effects

### DIFF
--- a/CWTools/Game/Compute.fs
+++ b/CWTools/Game/Compute.fs
@@ -95,6 +95,24 @@ module STL =
     open CWTools.Common.STLConstants
     open CWTools.Validation.Stellaris
 
+    let getScriptedEffectParams (node : Node) =
+        let getDollarText (s : string) (acc) =
+            s.Split('$') |> Array.mapi (fun i s -> i, s) |> Array.fold (fun acc (i, s) ->
+                if i % 2 = 1 then (s.Split('|').[0], s.Contains('|'))::acc else acc
+            ) acc
+            // let split = s.Split([|'$'|],3)
+            // if split.Length = 3 then split.[1]::acc else acc
+        let fNode = (fun (x:Node) acc ->
+            let nodeRes = getDollarText x.Key acc
+            x.Values |> List.fold (fun a n -> getDollarText n.Key (getDollarText (n.Value.ToRawString()) a)) nodeRes
+            )
+        node |> (foldNode7 fNode) |> List.ofSeq
+
+    let getScriptedEffectParamsEntity (e : Entity) =
+        if (e.logicalpath.StartsWith("common/scripted_effects", StringComparison.OrdinalIgnoreCase)
+                    || e.logicalpath.StartsWith("common/scripted_triggers", StringComparison.OrdinalIgnoreCase))
+                then getScriptedEffectParams (e.entity) else []
+
     let getAllTechPrereqs (e : Entity) =
         let fNode = (fun (x : Node) acc ->
                             match x with
@@ -180,7 +198,7 @@ module STL =
         // let definedvariable = (if infoService().IsSome then Some ((infoService().Value.GetDefinedVariables )(e)) else None)
         // let effectBlocks, triggersBlocks = (if infoService().IsSome then let (e, t) = ((infoService().Value.GetEffectBlocks )(e)) in Some e, Some t else None, None)
         let hastechs = getAllTechPrereqs e
-        let scriptedeffectparams = Some (EU4.getScriptedEffectParamsEntity e)
+        let scriptedeffectparams = Some (getScriptedEffectParamsEntity e)
         let referencedtypes = referencedtypes |> Option.map (fun r -> r |>  List.ofSeq |> List.fold (fun acc (kv) -> acc |> (Map.add kv.Key (kv.Value))) Map.empty )
         let referencedtypes = referencedtypes |> Option.map (fun r -> r |> Map.map (fun k v -> (v.ToArray() |> List.ofSeq)))
         STLComputedData(eventIds, setvariables, setflags, savedeventtargets, referencedtypes, hastechs, definedvariable, withRulesData, effectBlocks, triggersBlocks, scriptedeffectparams, savedEventTargets)

--- a/CWTools/Validation/Common/CommonValidation.fs
+++ b/CWTools/Validation/Common/CommonValidation.fs
@@ -136,7 +136,13 @@ module CommonValidation =
                         location = callSite
                         message = sprintf "This call of scripted effect %s results in an error" name
                     }
-                    res |> (function
+                    let requiredParams = CWTools.Games.Compute.STL.getScriptedEffectParams  rootNode |> List.filter (fun (_, optional) -> not optional) |> List.map fst
+                    let usedParams = seParams |> List.map fst
+                    let missingParams = List.except requiredParams usedParams
+                    let newError = if List.length missingParams > 0
+                        then Invalid (System.Guid.NewGuid(), [inv (ErrorCodes.CustomError "Some non optional parameters are not supplied" Severity.Error) node])
+                        else OK
+                    (res <&&> newError) |> (function
                             | OK -> OK
                             | Invalid (_, inv) -> Invalid (System.Guid.NewGuid(), inv |> List.map (fun e -> { e with relatedErrors = Some message })))
                 let memoizeValidation =


### PR DESCRIPTION
Optional parameters are now properly parsed (`$AMOUNT|1$` => `AMOUNT` and no longer `AMOUNT|1`)
Add custom rule that checks that all non optional parameters are supplied when calling a scripted effect