### PR TITLE
EU4: recognize global_event_target as an event_target

### DIFF
--- a/CWTools/Game/EU4/EU4Game.fs
+++ b/CWTools/Game/EU4/EU4Game.fs
@@ -30,6 +30,8 @@ module EU4GameFunctions =
         let eventtargets =
             (lookup.varDefInfo.TryFind "event_target" |> Option.defaultValue [] |> List.map fst)
             @
+            (lookup.varDefInfo.TryFind "global_event_target" |> Option.defaultValue [] |> List.map fst)
+            @
             (lookup.typeDefInfo.TryFind "province_id" |> Option.defaultValue [] |> List.map (fun tdi -> tdi.id))
             @
             (lookup.enumDefs.TryFind "country_tags" |> Option.map (fun x -> (snd x) |> List.map fst) |> Option.defaultValue [])


### PR DESCRIPTION
This allows effects and triggers for manipulating global_event_targets to be recognized in localisation of eu4.

This change is already present in hoi4 from which the line was copied.

Unfortunately I cannot test myself as I cannot even build the project on Linux.